### PR TITLE
docs(root): add canonical README, docs index, ports & troubleshooting…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,14 @@ lerna-debug.log*
 .DS_Store
 Thumbs.db
 
+# Local-only folders and artifacts
+logs 2/
+*.dump
+coverage/
+
+# For local-only scratch integration directories, prefer naming them integration-local/
+integration-local/
+
 # Optional editor directories
 .idea
 .vscode/*
@@ -32,4 +40,4 @@ Thumbs.db
 *.sublime-workspace
 
 # Optional eslint cache
-.eslintcache integration
+.eslintcache

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# NightBFF Backend – Local & Integration Guide
+
+This repository hosts the NightBFF backend and local integration harness. Use this README as the canonical quickstart for Local Development, Integration testing, and Performance experiments.
+
+## Stacks at a glance
+- Local Dev: backend 3001, Postgres 5434, Redis 6379
+- Integration: backend 3000, Postgres 5435, Metro 8081
+- Performance: dedicated compose; recommend Postgres host port 5436+
+
+## Quickstart
+- Local DB (from `app/`):
+  - `npm run dev:db`  # Postgres 5434, Redis 6379
+- Local backend (from `app/`):
+  - `npm run start:dev`  # binds 3001
+- Integration stack (from repo root):
+  - `docker compose -f integration/docker-compose.yaml up -d`
+  - Backend health: http://localhost:3000/health
+- Performance stack (from repo root):
+  - `HOST_POSTGRES_PORT=5436 docker compose -f performance-testing/docker/docker-compose.performance.yml up -d`
+
+## Useful health checks
+- Integration backend: `GET http://localhost:3000/health`
+- Local backend: `GET http://localhost:3001/health`
+
+## References
+- `HYBRID_INTEGRATION_DEV_PLAN.md`
+- `EVERGREEN_CI_PIPELINE_STATUS_CHECKER.md`
+- ADRs under `docs/adr/`
+- Frontend integration guides under `app/`
+
+# NightBFF Backend – Local & Integration Guide
+
+This repository hosts the NightBFF backend and local integration harness. Use this README as the canonical quickstart for Local Development, Integration testing, and Performance experiments.
+
+## Stacks at a glance
+- Local Dev: backend 3001, Postgres 5434, Redis 6379
+- Integration: backend 3000, Postgres 5435, Metro 8081
+- Performance: dedicated compose; recommend Postgres host port 5436+
+
+## Quickstart
+- Local DB (from `app/`):
+  - `npm run dev:db`  # Postgres 5434, Redis 6379
+- Local backend (from `app/`):
+  - `npm run start:dev`  # binds 3001
+- Integration stack (from repo root):
+  - `docker compose -f integration/docker-compose.yaml up -d`
+  - Backend health: http://localhost:3000/health
+- Performance stack (from repo root):
+  - `HOST_POSTGRES_PORT=5436 docker compose -f performance-testing/docker/docker-compose.performance.yml up -d`
+
+## Useful health checks
+- Integration backend: `GET http://localhost:3000/health`
+- Local backend: `GET http://localhost:3001/health`
+
+## References
+- `HYBRID_INTEGRATION_DEV_PLAN.md`
+- `EVERGREEN_CI_PIPELINE_STATUS_CHECKER.md`
+- ADRs under `docs/adr/`
+- Frontend integration guides under `app/`
+

--- a/config/env/README.md
+++ b/config/env/README.md
@@ -1,34 +1,5 @@
-# NightBFF Environment Configuration
+# Environment Locations
 
-## Centralized Environment Loader (2025-07-20)
-
-**All direct Node scripts must load environment variables via the centralized loader.**
-
-### Usage Pattern
-
-- For any script run from compiled JS (dist/):
-  ```sh
-  node --require ./dist/scripts/load-env.js dist/scripts/migrate.js
-  ```
-- For npm scripts, ensure the `--require ./dist/scripts/load-env.js` flag is present in `package.json`.
-- Do **not** manually import `dotenv` or load envs in individual scripts.
-
-### Why?
-- Guarantees all scripts (migrate, seed, validate, etc.) load envs from `config/env/`.
-- Eliminates “works on my machine” bugs.
-- Future-proofs CI/CD and onboarding.
-
-### Troubleshooting
-- If you see missing env errors, check that the loader is required in your script invocation.
-- If you run scripts directly, always use the preload flag.
-- For TypeScript scripts run with `ts-node`, use:
-  ```sh
-  ts-node --require ./scripts/load-env scripts/seed-loadtest-data.ts
-  ```
-
-### Enforcement
-- CI will fail if scripts are missing the loader (see .github/scripts/check-env-loader.js).
-
----
-
-For more, see [ENV_CENTRALIZATION_ACTION_PLAN.md](../../REBASE & RECONCILIATION/ENV_CENTRALIZATION_ACTION_PLAN.md) 
+Runtime env files for the backend live under `app/config/env/`.
+This `config/env/` directory is for consolidated templates/docs only.
+Do not commit secrets. See `docs/SECURE_ENV.md` if present. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,6 @@
+## NOTE: Legacy development compose
+## Prefer using `docker-compose.local.yml` for Local Dev (fixed Postgres 5434, Redis 6379).
+## Do not run this concurrently with the Integration stack.
 version: '3.8'
 
 services:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,9 @@
+# NightBFF Documentation Index
+
+- Hybrid Integration Plan: `../HYBRID_INTEGRATION_DEV_PLAN.md`
+- Evergreen CI Status Checker: `../EVERGREEN_CI_PIPELINE_STATUS_CHECKER.md`
+- ADRs: `./adr/`
+- Environment Security: `./SECURE_ENV.md`
+- Ports: `./PORTS.md`
+- Troubleshooting: `./TROUBLESHOOTING.md`
+- Frontend Integration Guides: `../app/`

--- a/docs/PORTS.md
+++ b/docs/PORTS.md
@@ -1,0 +1,12 @@
+# Port Policy
+
+Reserved host ports and ownership:
+
+- Local Dev: backend 3001, Postgres 5434, Redis 6379
+- Integration: backend 3000, Postgres 5435, Metro 8081
+- Performance: Postgres suggested starting at 5436 (set `HOST_POSTGRES_PORT` explicitly)
+
+Notes:
+- Fixed ports avoid drift after reboots and prevent EADDRINUSE.
+- If a reserved port is occupied, pick another free port and export it inline for compose, e.g.:
+  - `HOST_POSTGRES_PORT=5440 docker compose -f performance-testing/docker/docker-compose.performance.yml up -d`

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,20 @@
+# Troubleshooting
+
+## Backend cannot bind (EADDRINUSE)
+- Symptom: "EADDRINUSE: address already in use" on 3000/3001.
+- Check who holds the port:
+  - `lsof -nP -iTCP -sTCP:LISTEN | egrep ':(3000|3001)'`
+- Resolution:
+  - Integration uses 3000. Run local backend on 3001.
+
+## DB ECONNREFUSED in Local Dev
+- Symptom: TypeORM retries to `127.0.0.1:<port>` and fails.
+- Check Postgres mapping:
+  - `docker ps | egrep 'nightbff_postgres_local'`
+  - Expect `0.0.0.0:5434->5432/tcp`
+- Resolution:
+  - Ensure `POSTGRES_PORT=5434` in `app/config/env/development.env` and re-run `npm run dev:db`.
+
+## Quick health checks
+- Integration backend: `curl -s http://localhost:3000/health`
+- Local backend: `curl -s http://localhost:3001/health`


### PR DESCRIPTION
…; add legacy compose header; tighten .gitignore\n\n- Quickstart for Local Dev (3001/5434), Integration (3000/5435), Perf (HOST_POSTGRES_PORT=5436)\n- Non-functional header warning in docker-compose.yml\n- No CI/workflow/code changes