### PR TITLE
docs(hygiene): add PR/Issue templates, editorconfig, and rollout plan…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+## Describe the bug
+
+## Steps to reproduce
+
+## Expected behavior
+
+## Actual behavior / logs
+
+## Environment
+- OS:
+- Branch:
+- Commit/SHA:
+
+## Additional context

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+## Problem / context
+
+## Proposal
+
+## Acceptance Criteria
+
+## Risks / tradeoffs
+
+## Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+Describe the change.
+
+## Type
+- [ ] docs-only
+- [ ] chore
+- [ ] fix
+- [ ] feat
+
+## Checklist
+- [ ] CI green
+- [ ] No secrets committed
+- [ ] Local runbook tested (if applicable)
+- [ ] Docs updated (README/INDEX/ADR where needed)
+
+## Risk
+- [ ] low
+- [ ] medium
+- [ ] high

--- a/docs/REPO_HYGIENE_ROLLOUT.md
+++ b/docs/REPO_HYGIENE_ROLLOUT.md
@@ -1,0 +1,18 @@
+# Repository Hygiene Rollout Plan (Backend + Integration)
+
+Scope: Non-functional, CI-neutral hygiene. Applies to backend now; mirror in integration repo via separate PR.
+
+## Backend (this repo)
+- Add PR/Issue templates and .editorconfig (done in this branch)
+- Keep docs-only PRs labeled and gated by CI green
+- No secrets policy reinforced in templates
+
+## Integration repo (follow-up PR)
+- Add same templates and .editorconfig
+- Ensure submodule sanity checks remain (no cyclic references)
+- Document compose usage and ports in its README (align with backend README)
+
+## Process
+- Open PRs labeled `docs-only` / `hygiene`
+- Require 1 reviewer from backend + 1 from iOS
+- Merge once CI green (no workflow changes included)


### PR DESCRIPTION
… (backend now; mirror to integration via separate PR)\n\n- CI-neutral, non-functional changes\n- Reinforce no-secrets and review gates